### PR TITLE
ci: enable Codecov coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
       # Tests: added once the test framework is decided (ADR-006)
 
       - name: Upload coverage to Codecov
+        if: hashFiles('coverage/**') != ''
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
CODECOV_TOKEN and RELEASE_PLEASE_TOKEN secrets are now configured. Uncomments the `codecov/codecov-action@v5` step in the slow-checks job.

closes #3