### PR TITLE
docs: add ADR-014 (Hono) and ADR-015 (Vitest/Playwright)

### DIFF
--- a/docs/decisions/ADR-014-backend-http-server-framework.md
+++ b/docs/decisions/ADR-014-backend-http-server-framework.md
@@ -1,0 +1,43 @@
+---
+number: ADR-014
+title: Backend HTTP Server Framework
+status: accepted
+date: 2026-03-17
+---
+
+# ADR-014: Backend HTTP Server Framework
+
+## Status
+
+Accepted
+
+## Rationale
+
+The Node.js backend (ADR-002) must expose REST endpoints for the frontend and stream AG-UI Server-Sent Events (SSE) to the browser (ADR-003). An HTTP server framework must be chosen before any backend routes can be built. No framework may be introduced without an accepted ADR (per ADR-006 principles applied to all architectural components).
+
+## Decision
+
+**Hono** is used as the HTTP server framework for the Node.js backend, running via `@hono/node-server`.
+
+Key reasons:
+
+- **First-class SSE streaming** — Hono's built-in `streamSSE()` helper directly supports the AG-UI SSE transport required by ADR-003, with no manual `res.write()` plumbing.
+- **TypeScript-first DX** — typed routes and typed middleware with no additional configuration; aligns with the TypeScript-only constraint in ADR-002.
+- **Minimal surface area** — no heavy abstractions or opinionated project structure; easier to reason about and test routes in isolation.
+- **Native Node.js adapter** — `@hono/node-server` wraps the standard Node.js `http` module, keeping the runtime dependency on Node.js only (ADR-002).
+- **Testability** — Hono apps can be tested with `app.request()` in unit/integration tests without starting a real HTTP server, fitting the Vitest-based test setup (ADR-015).
+
+## Rejected Alternatives
+
+| Alternative | Reason Rejected |
+|---|---|
+| Express | Battle-tested but requires manual SSE implementation (`res.write` / `res.flush`), weaker TypeScript ergonomics, no built-in SSE helper |
+| Fastify | Solid option but more configuration overhead for SSE streaming; less ergonomic TS route typing |
+| FastAPI (Python) | Would supersede ADR-002 (Node.js runtime) and introduce a language boundary between frontend TypeScript types and backend; incompatible with the ACP TypeScript SDK (ADR-003) |
+
+## Agent Instructions
+
+- Use `hono` and `@hono/node-server` for all backend HTTP route definitions and the server entry point.
+- Use Hono's `streamSSE()` helper for all SSE endpoints — do not implement SSE manually via `res.write`.
+- Do not introduce any other HTTP server framework alongside or instead of Hono without a new ADR.
+- Keep route handlers thin; delegate business logic to separate modules so routes remain independently testable via `app.request()`.

--- a/docs/decisions/ADR-015-test-framework-selection.md
+++ b/docs/decisions/ADR-015-test-framework-selection.md
@@ -1,0 +1,51 @@
+---
+number: ADR-015
+title: Test Framework Selection
+status: accepted
+date: 2026-03-17
+---
+
+# ADR-015: Test Framework Selection
+
+## Status
+
+Accepted — fulfils the deferred framework decision in ADR-006.
+
+## Rationale
+
+ADR-006 mandates unit, integration, and E2E tests but explicitly deferred the framework choice. No test framework may be introduced before this decision is recorded. This ADR selects frameworks for all three categories.
+
+## Decision
+
+| Category | Framework |
+|---|---|
+| Unit + integration | **Vitest** |
+| React component tests | **@testing-library/react** (on top of Vitest) |
+| E2E | **Playwright** |
+| Coverage provider | **V8** (via Vitest's built-in coverage) |
+
+**Vitest** — uses the same Vite transform pipeline already present in the project (ADR-013), requiring zero additional build configuration. ESM-native, fast watch mode, and Jest-compatible API for a low migration cost if needed. Built-in V8 coverage satisfies the Codecov upload requirement in ADR-005 (≥ 85% patch coverage).
+
+**@testing-library/react** — idiomatic React component testing without a real browser; pairs naturally with Vitest's jsdom/happy-dom environment. Encourages testing from the user's perspective rather than implementation details.
+
+**Playwright** — industry-standard E2E framework with first-class TypeScript support. Its `webServer` option integrates cleanly with the Vite dev server (ADR-013), starting the app automatically before test runs. Covers the browser-level user flows required by ADR-006.
+
+**V8 coverage** — native Node.js/V8 instrumentation, no Babel transform required; lower overhead than Istanbul/nyc. Outputs standard LCOV reports consumed by Codecov (ADR-005).
+
+## Rejected Alternatives
+
+| Alternative | Reason Rejected |
+|---|---|
+| Jest | Requires additional Vite/ESM transform setup; duplicates configuration already present for Vitest; slower than Vitest for this stack |
+| Mocha + Chai | More manual wiring; no built-in coverage; no first-class Vite integration |
+| Cypress | Heavier than Playwright; Playwright preferred for superior TypeScript DX and Vite integration |
+| Istanbul/nyc coverage | Requires Babel instrumentation; V8 coverage is lower-overhead and natively supported by Vitest |
+
+## Agent Instructions
+
+- Use **Vitest** for all unit and integration tests. Do not introduce Jest or Mocha.
+- Use **@testing-library/react** for React component tests within the Vitest environment.
+- Use **Playwright** for all E2E tests. Configure the `webServer` option to start the Vite dev server before E2E runs.
+- Configure Vitest with the **V8 coverage provider** and output LCOV reports for Codecov upload (ADR-005).
+- Do not introduce any additional test framework without a new ADR.
+- All new code must include unit tests per ADR-006. New user-facing flows must include integration or E2E tests.


### PR DESCRIPTION
## Summary

Adds two new ADRs to fulfil open governance decisions:

- **ADR-014** — selects Hono + `@hono/node-server` as the backend HTTP server framework (first-class SSE via `streamSSE()`, TypeScript-first, minimal surface area).
- **ADR-015** — fulfils the deferred test framework decision in ADR-006: Vitest for unit/integration, `@testing-library/react` for components, Playwright for E2E, V8 for coverage.

Both ADRs pass `node docs/decisions/validate-adrs.mjs`.

closes #6
closes #7