### PR TITLE
feat: scaffold Hono backend server with SSE endpoint and Copilot ACP adapter

### DIFF
--- a/backend/src/adapters/copilot/adapter.test.ts
+++ b/backend/src/adapters/copilot/adapter.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { EventEmitter } from 'node:events'
+import { CopilotAdapter } from './adapter.js'
+import type { ProcessFactory, ClientFactory } from './adapter.js'
+import type { AgUiEvent } from './types.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeProcessFactory(port = 9999): ProcessFactory {
+  return vi.fn().mockImplementation((onExit: (code: number | null) => void) => ({
+    start: vi.fn().mockResolvedValue(port),
+    stop: vi.fn(),
+    port,
+    _simulateExit: (code: number | null) => onExit(code),
+  }))
+}
+
+function makeClientFactory(events: Array<object> = []): ClientFactory {
+  return vi.fn().mockImplementation(() => ({
+    runStream: vi.fn().mockImplementation(async function* () {
+      for (const event of events) yield event
+    }),
+  }))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CopilotAdapter', () => {
+  let createProcess: ReturnType<typeof makeProcessFactory>
+  let createClient: ReturnType<typeof makeClientFactory>
+  let adapter: CopilotAdapter
+
+  beforeEach(() => {
+    createProcess = makeProcessFactory()
+    createClient = makeClientFactory()
+    adapter = new CopilotAdapter(createProcess, createClient)
+  })
+
+  describe('newSession()', () => {
+    it('spawns a process and returns a UUID', async () => {
+      const sessionId = await adapter.newSession()
+      expect(typeof sessionId).toBe('string')
+      expect(sessionId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      )
+    })
+
+    it('calls createProcess and proc.start()', async () => {
+      await adapter.newSession()
+      expect(createProcess).toHaveBeenCalledOnce()
+      const proc = (createProcess as ReturnType<typeof vi.fn>).mock.results[0].value
+      expect(proc.start).toHaveBeenCalledOnce()
+    })
+
+    it('increments sessionCount', async () => {
+      expect(adapter.sessionCount).toBe(0)
+      await adapter.newSession()
+      expect(adapter.sessionCount).toBe(1)
+    })
+  })
+
+  describe('sendMessage()', () => {
+    it('throws if session does not exist', async () => {
+      await expect(adapter.sendMessage('nonexistent', 'hi')).rejects.toThrow('Session not found')
+    })
+
+    it('emits RUN_STARTED and RUN_FINISHED for an empty stream', async () => {
+      const sessionId = await adapter.newSession()
+      const emitted: AgUiEvent[] = []
+      adapter.events.on(sessionId, (e: AgUiEvent) => emitted.push(e))
+
+      await adapter.sendMessage(sessionId, 'hello')
+
+      expect(emitted[0]).toMatchObject({ type: 'RUN_STARTED' })
+      expect(emitted[emitted.length - 1]).toMatchObject({ type: 'RUN_FINISHED' })
+    })
+
+    it('translates message.part (text) to TEXT_MESSAGE_CONTENT', async () => {
+      createClient = makeClientFactory([
+        { type: 'message.part', part: { content_type: 'text/plain', content: 'Hi there' } },
+      ])
+      adapter = new CopilotAdapter(createProcess, createClient)
+
+      const sessionId = await adapter.newSession()
+      const emitted: AgUiEvent[] = []
+      adapter.events.on(sessionId, (e: AgUiEvent) => emitted.push(e))
+
+      await adapter.sendMessage(sessionId, 'hello')
+
+      const textEvent = emitted.find((e) => e.type === 'TEXT_MESSAGE_CONTENT')
+      expect(textEvent).toBeDefined()
+      expect(textEvent?.data).toMatchObject({ content: 'Hi there' })
+    })
+
+    it('translates message.part (tool-call) to TOOL_CALL_START', async () => {
+      createClient = makeClientFactory([
+        {
+          type: 'message.part',
+          part: { content_type: 'application/x-tool-call', name: 'readFile', content: '{}' },
+        },
+      ])
+      adapter = new CopilotAdapter(createProcess, createClient)
+
+      const sessionId = await adapter.newSession()
+      const emitted: AgUiEvent[] = []
+      adapter.events.on(sessionId, (e: AgUiEvent) => emitted.push(e))
+
+      await adapter.sendMessage(sessionId, 'hello')
+
+      const toolEvent = emitted.find((e) => e.type === 'TOOL_CALL_START')
+      expect(toolEvent).toBeDefined()
+      expect(toolEvent?.data).toMatchObject({ name: 'readFile' })
+    })
+
+    it('emits RUN_ERROR if the ACP stream throws', async () => {
+      const throwingIterable: AsyncIterable<never> = {
+        [Symbol.asyncIterator](): AsyncIterator<never> {
+          return {
+            next(): Promise<IteratorResult<never>> {
+              return Promise.reject(new Error('connection refused'))
+            },
+          }
+        },
+      }
+      createClient = vi.fn().mockImplementation(() => ({
+        runStream: vi.fn().mockReturnValue(throwingIterable),
+      }))
+      adapter = new CopilotAdapter(createProcess, createClient)
+
+      const sessionId = await adapter.newSession()
+      const emitted: AgUiEvent[] = []
+      adapter.events.on(sessionId, (e: AgUiEvent) => emitted.push(e))
+
+      await adapter.sendMessage(sessionId, 'hello')
+
+      const errEvent = emitted.find((e) => e.type === 'RUN_ERROR')
+      expect(errEvent).toBeDefined()
+      expect((errEvent?.data as { message: string }).message).toContain('connection refused')
+    })
+  })
+
+  describe('closeSession()', () => {
+    it('stops the process and removes the session', async () => {
+      const sessionId = await adapter.newSession()
+      expect(adapter.sessionCount).toBe(1)
+
+      adapter.closeSession(sessionId)
+
+      expect(adapter.sessionCount).toBe(0)
+      const proc = (createProcess as ReturnType<typeof vi.fn>).mock.results[0].value
+      expect(proc.stop).toHaveBeenCalledOnce()
+    })
+
+    it('removes all event listeners for the session', async () => {
+      const sessionId = await adapter.newSession()
+      const listener = vi.fn()
+      adapter.events.on(sessionId, listener)
+      expect(new EventEmitter().listenerCount(sessionId)).toBe(0)
+
+      adapter.closeSession(sessionId)
+
+      expect(adapter.events.listenerCount(sessionId)).toBe(0)
+    })
+  })
+})

--- a/backend/src/adapters/copilot/adapter.ts
+++ b/backend/src/adapters/copilot/adapter.ts
@@ -1,0 +1,160 @@
+import { EventEmitter } from 'node:events'
+import { randomUUID } from 'node:crypto'
+import type { Client, Event as AcpEvent, MessagePart } from 'acp-sdk'
+import type { CopilotProcess } from './process.js'
+import type { AgUiEvent, SessionState } from './types.js'
+
+export type ProcessFactory = (onExit: (code: number | null) => void) => CopilotProcess
+export type ClientFactory = (port: number) => Client
+
+export class CopilotAdapter {
+  private readonly sessions = new Map<string, SessionState>()
+  /** EventEmitter used to push AG-UI events to the SSE stream endpoint. */
+  readonly events = new EventEmitter()
+
+  constructor(
+    private readonly createProcess: ProcessFactory,
+    private readonly createClient: ClientFactory,
+  ) {}
+
+  /**
+   * Spawn the Copilot CLI subprocess and register a new session.
+   * mcpServers (from mcp.json) are stored and injected into the first ACP run
+   * per ADR-003.
+   */
+  async newSession(mcpServers: Record<string, unknown> = {}): Promise<string> {
+    const sessionId = randomUUID()
+
+    const proc = this.createProcess((code) => {
+      this.sessions.delete(sessionId)
+      this.events.emit(sessionId, {
+        type: 'RUN_ERROR',
+        data: { message: `Copilot process exited with code ${String(code)}` },
+      } satisfies AgUiEvent)
+    })
+
+    await proc.start()
+
+    this.sessions.set(sessionId, {
+      id: sessionId,
+      createdAt: new Date(),
+      agentProcess: proc,
+      mcpServers,
+      firstMessageSent: false,
+    })
+
+    return sessionId
+  }
+
+  /**
+   * Forward a user message to the Copilot ACP server and stream translated
+   * AG-UI events onto `this.events` for the given sessionId.
+   *
+   * This method fires asynchronously — the caller does not need to await the
+   * full stream; events arrive on the EventEmitter as they are produced.
+   */
+  async sendMessage(sessionId: string, text: string): Promise<void> {
+    const session = this.sessions.get(sessionId)
+    if (session === undefined) {
+      throw new Error(`Session not found: ${sessionId}`)
+    }
+
+    const client = this.createClient(session.agentProcess.port!)
+    const input = this.buildInput(session, text)
+
+    // Mark that the first message has been sent (so mcpServers are not re-injected)
+    session.firstMessageSent = true
+
+    this.events.emit(sessionId, { type: 'RUN_STARTED', data: { sessionId } } satisfies AgUiEvent)
+
+    try {
+      for await (const event of client.runStream('copilot', input)) {
+        const agUi = this.translateAcpEvent(event)
+        if (agUi !== null) {
+          this.events.emit(sessionId, agUi)
+        }
+      }
+      this.events.emit(sessionId, { type: 'RUN_FINISHED', data: { sessionId } } satisfies AgUiEvent)
+    } catch (err: unknown) {
+      this.events.emit(sessionId, {
+        type: 'RUN_ERROR',
+        data: { message: err instanceof Error ? err.message : String(err) },
+      } satisfies AgUiEvent)
+    }
+  }
+
+  closeSession(sessionId: string): void {
+    const session = this.sessions.get(sessionId)
+    session?.agentProcess.stop()
+    this.sessions.delete(sessionId)
+    this.events.removeAllListeners(sessionId)
+  }
+
+  get sessionCount(): number {
+    return this.sessions.size
+  }
+
+  /**
+   * Build the ACP input for a run.
+   * On the first message of a session, the mcpServers configuration is injected
+   * as an additional JSON part per ADR-003. The exact field name follows the
+   * ACP server's initialization parameters contract.
+   */
+  private buildInput(session: SessionState, text: string): string | MessagePart[] {
+    if (!session.firstMessageSent && Object.keys(session.mcpServers).length > 0) {
+      // Inject mcpServers as a structured part per ADR-003. The MCP config
+      // part is prepended so the ACP server can extract it at initialization time.
+      return [
+        {
+          name: 'mcp-config',
+          content_type: 'application/json',
+          content_encoding: 'plain',
+          content: JSON.stringify({ mcpServers: session.mcpServers }),
+        } satisfies MessagePart,
+        {
+          content_type: 'text/plain',
+          content_encoding: 'plain',
+          content: text,
+        } satisfies MessagePart,
+      ]
+    }
+    return text
+  }
+
+  /**
+   * Translate an ACP Event into an AG-UI event.
+   * Returns null for events that have no AG-UI representation.
+   *
+   * Mapping (ADR-003):
+   *   message.part (text)        → TEXT_MESSAGE_CONTENT
+   *   message.part (tool-call)   → TOOL_CALL_START
+   *   message.part (tool-result) → TOOL_CALL_RESULT
+   *   run.failed / error         → RUN_ERROR (emitted by catch block)
+   */
+  private translateAcpEvent(event: AcpEvent): AgUiEvent | null {
+    if (event.type === 'message.part') {
+      const { part } = event
+      const contentType = part.content_type ?? 'text/plain'
+
+      if (contentType.includes('tool-call')) {
+        return {
+          type: 'TOOL_CALL_START',
+          data: { name: part.name ?? null, content: part.content ?? null },
+        }
+      }
+
+      if (contentType.includes('tool-result')) {
+        return {
+          type: 'TOOL_CALL_RESULT',
+          data: { name: part.name ?? null, content: part.content ?? null },
+        }
+      }
+
+      // Default: treat as streaming text
+      return { type: 'TEXT_MESSAGE_CONTENT', data: { content: part.content ?? '' } }
+    }
+
+    // run.failed is handled by the catch block in sendMessage; no mapping needed here
+    return null
+  }
+}

--- a/backend/src/adapters/copilot/index.ts
+++ b/backend/src/adapters/copilot/index.ts
@@ -1,0 +1,3 @@
+export { CopilotAdapter } from './adapter.js'
+export { CopilotProcess } from './process.js'
+export type { AgUiEvent, AgUiEventType, SessionState } from './types.js'

--- a/backend/src/adapters/copilot/process.ts
+++ b/backend/src/adapters/copilot/process.ts
@@ -1,0 +1,78 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+
+/**
+ * Default command to start the Copilot CLI in ACP server mode.
+ * Override with COPILOT_ACP_CMD and COPILOT_ACP_ARGS env vars.
+ *
+ * NOTE: GitHub Copilot CLI ACP support is in development. The exact
+ * command will be confirmed once the CLI ships ACP server mode.
+ */
+const DEFAULT_CMD = process.env['COPILOT_ACP_CMD'] ?? 'gh'
+const DEFAULT_ARGS = (process.env['COPILOT_ACP_ARGS'] ?? 'copilot serve').split(' ')
+
+const START_TIMEOUT_MS = 30_000
+
+export interface CopilotProcessOptions {
+  command?: string
+  args?: string[]
+  onExit?: (code: number | null) => void
+}
+
+export class CopilotProcess {
+  private proc: ChildProcess | null = null
+  public port: number | null = null
+
+  constructor(private readonly options: CopilotProcessOptions = {}) {}
+
+  /**
+   * Spawn the Copilot CLI and wait until it reports the ACP server port.
+   * The process is expected to write either:
+   *   - a JSON line containing `"port": <number>`, or
+   *   - a plain-text line like "listening on port <number>"
+   * to stdout once the ACP server is ready.
+   */
+  start(): Promise<number> {
+    const cmd = this.options.command ?? DEFAULT_CMD
+    const args = this.options.args ?? DEFAULT_ARGS
+
+    this.proc = spawn(cmd, args, {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env },
+    })
+
+    return new Promise<number>((resolve, reject) => {
+      const timeout = setTimeout(
+        () => reject(new Error('CopilotProcess: timed out waiting for ACP server to start')),
+        START_TIMEOUT_MS,
+      )
+
+      this.proc!.stdout!.on('data', (chunk: Buffer) => {
+        const line = chunk.toString()
+        const jsonMatch = line.match(/"port"\s*:\s*(\d+)/)
+        const textMatch = line.match(/port\s+(\d+)/i)
+        const portStr = jsonMatch?.[1] ?? textMatch?.[1]
+        if (portStr !== undefined) {
+          const port = parseInt(portStr, 10)
+          this.port = port
+          clearTimeout(timeout)
+          resolve(port)
+        }
+      })
+
+      this.proc!.on('error', (err) => {
+        clearTimeout(timeout)
+        reject(err)
+      })
+
+      this.proc!.on('exit', (code) => {
+        this.options.onExit?.(code)
+      })
+    })
+  }
+
+  stop(): void {
+    if (this.proc !== null && !this.proc.killed) {
+      this.proc.kill('SIGTERM')
+    }
+  }
+}

--- a/backend/src/adapters/copilot/routes.ts
+++ b/backend/src/adapters/copilot/routes.ts
@@ -1,0 +1,51 @@
+import { Hono } from 'hono'
+import { loadMcpServers } from '../../mcp.js'
+import type { CopilotAdapter } from './adapter.js'
+
+export function copilotRoutes(adapter: CopilotAdapter): Hono {
+  const app = new Hono()
+
+  /**
+   * POST /api/agents/copilot/session/new
+   * Start a new Copilot agent session.
+   * Injects mcpServers from mcp.json per ADR-003.
+   */
+  app.post('/session/new', async (c) => {
+    const mcpServers = loadMcpServers()
+    const sessionId = await adapter.newSession(mcpServers)
+    return c.json({ sessionId }, 201)
+  })
+
+  /**
+   * POST /api/agents/copilot/session/message
+   * Forward a user message to the active Copilot session.
+   * Events are streamed to the client via GET /api/stream?sessionId=<id>.
+   */
+  app.post('/session/message', async (c) => {
+    const body = await c.req.json<{ sessionId: string; message: string }>()
+    const { sessionId, message } = body
+
+    if (!sessionId || !message) {
+      return c.json({ error: 'sessionId and message are required' }, 400)
+    }
+
+    // Fire-and-forget: events flow to the SSE stream endpoint asynchronously
+    void adapter.sendMessage(sessionId, message).catch(() => {
+      // Errors are emitted as RUN_ERROR events on the event bus inside sendMessage
+    })
+
+    return c.json({ accepted: true }, 202)
+  })
+
+  /**
+   * DELETE /api/agents/copilot/session/:id
+   * Tear down a session and its subprocess.
+   */
+  app.delete('/session/:id', (c) => {
+    const id = c.req.param('id')
+    adapter.closeSession(id)
+    return c.json({ closed: true })
+  })
+
+  return app
+}

--- a/backend/src/adapters/copilot/types.ts
+++ b/backend/src/adapters/copilot/types.ts
@@ -1,0 +1,27 @@
+import type { CopilotProcess } from './process.js'
+
+export interface SessionState {
+  id: string
+  createdAt: Date
+  agentProcess: CopilotProcess
+  /** mcpServers injected at session creation — forwarded on the first ACP run. */
+  mcpServers: Record<string, unknown>
+  firstMessageSent: boolean
+}
+
+/**
+ * AG-UI event types translated from ACP events.
+ * See ADR-003 for the full mapping specification.
+ */
+export type AgUiEventType =
+  | 'TEXT_MESSAGE_CONTENT'
+  | 'TOOL_CALL_START'
+  | 'TOOL_CALL_RESULT'
+  | 'RUN_STARTED'
+  | 'RUN_FINISHED'
+  | 'RUN_ERROR'
+
+export interface AgUiEvent {
+  type: AgUiEventType
+  data: unknown
+}

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,0 +1,13 @@
+import { Hono } from 'hono'
+import { healthRoutes } from './routes/health.js'
+import { streamRoute } from './routes/stream.js'
+import { copilotRoutes } from './adapters/copilot/routes.js'
+import type { CopilotAdapter } from './adapters/copilot/adapter.js'
+
+export function createApp(adapter: CopilotAdapter): Hono {
+  const app = new Hono()
+  app.route('/', healthRoutes())
+  app.route('/api', streamRoute(adapter))
+  app.route('/api/agents/copilot', copilotRoutes(adapter))
+  return app
+}

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,3 +1,17 @@
-const PORT = process.env['PORT'] ?? 3001
+import { serve } from '@hono/node-server'
+import { Client } from 'acp-sdk'
+import { createApp } from './app.js'
+import { CopilotAdapter, CopilotProcess } from './adapters/copilot/index.js'
 
-console.log(`ACP backend starting on port ${PORT}`)
+const PORT = Number(process.env['PORT'] ?? 3001)
+
+const adapter = new CopilotAdapter(
+  (onExit) => new CopilotProcess({ onExit }),
+  (port) => new Client({ baseUrl: `http://127.0.0.1:${port}` }),
+)
+
+const app = createApp(adapter)
+
+serve({ fetch: app.fetch, hostname: '127.0.0.1', port: PORT }, () => {
+  console.log(`ACP backend listening on http://127.0.0.1:${PORT}`)
+})

--- a/backend/src/mcp.ts
+++ b/backend/src/mcp.ts
@@ -1,0 +1,27 @@
+import { readFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+interface McpServerConfig {
+  command: string
+  args?: string[]
+  env?: Record<string, string>
+}
+
+interface McpConfig {
+  mcpServers: Record<string, McpServerConfig>
+}
+
+const MCP_JSON_PATH = process.env['MCP_JSON_PATH'] ?? join(process.cwd(), 'mcp.json')
+
+export function loadMcpServers(): Record<string, McpServerConfig> {
+  if (!existsSync(MCP_JSON_PATH)) {
+    return {}
+  }
+  try {
+    const raw = readFileSync(MCP_JSON_PATH, 'utf8')
+    const config = JSON.parse(raw) as McpConfig
+    return config.mcpServers ?? {}
+  } catch {
+    return {}
+  }
+}

--- a/backend/src/routes/health.test.ts
+++ b/backend/src/routes/health.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { healthRoutes } from '../routes/health.js'
+
+describe('GET /health', () => {
+  const app = healthRoutes()
+
+  it('returns 200', async () => {
+    const res = await app.request('/health')
+    expect(res.status).toBe(200)
+  })
+
+  it('returns { status: "ok" }', async () => {
+    const res = await app.request('/health')
+    const body = await res.json()
+    expect(body).toEqual({ status: 'ok' })
+  })
+
+  it('responds with application/json content-type', async () => {
+    const res = await app.request('/health')
+    expect(res.headers.get('content-type')).toContain('application/json')
+  })
+})

--- a/backend/src/routes/health.ts
+++ b/backend/src/routes/health.ts
@@ -1,0 +1,7 @@
+import { Hono } from 'hono'
+
+export function healthRoutes(): Hono {
+  const app = new Hono()
+  app.get('/health', (c) => c.json({ status: 'ok' }))
+  return app
+}

--- a/backend/src/routes/stream.ts
+++ b/backend/src/routes/stream.ts
@@ -1,0 +1,36 @@
+import { Hono } from 'hono'
+import { streamSSE } from 'hono/streaming'
+import type { CopilotAdapter } from '../adapters/copilot/adapter.js'
+import type { AgUiEvent } from '../adapters/copilot/types.js'
+
+export function streamRoute(adapter: CopilotAdapter): Hono {
+  const app = new Hono()
+
+  app.get('/stream', (c) => {
+    const sessionId = c.req.query('sessionId')
+    if (!sessionId) {
+      return c.json({ error: 'sessionId query parameter is required' }, 400)
+    }
+
+    return streamSSE(c, async (stream) => {
+      const listener = (event: AgUiEvent) => {
+        void stream.writeSSE({
+          event: event.type,
+          data: JSON.stringify(event.data),
+        })
+      }
+
+      adapter.events.on(sessionId, listener)
+      stream.onAbort(() => {
+        adapter.events.off(sessionId, listener)
+      })
+
+      // Keep the connection open until the client disconnects
+      await new Promise<void>((resolve) => {
+        stream.onAbort(resolve)
+      })
+    })
+  })
+
+  return app
+}

--- a/package.json
+++ b/package.json
@@ -14,12 +14,18 @@
     "build:frontend": "vite build",
     "build:backend": "tsc -p backend/tsconfig.build.json",
     "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
     "lint": "eslint .",
     "typecheck": "tsc -p frontend/tsconfig.json && tsc -p backend/tsconfig.json",
     "prepare": "husky"
   },
   "dependencies": {
+    "@hono/node-server": "^1.19.11",
     "@tanstack/react-router": "^1.0.0",
+    "acp-sdk": "^1.0.3",
+    "hono": "^4.12.8",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"
   },
@@ -35,6 +41,7 @@
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.0.0",
+    "@vitest/coverage-v8": "^4.1.0",
     "eslint": "^9.0.0",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.0",
@@ -45,6 +52,7 @@
     "tsx": "^4.0.0",
     "typescript": "^5.0.0",
     "typescript-eslint": "^8.0.0",
-    "vite": "^6.0.0"
+    "vite": "^6.0.0",
+    "vitest": "^4.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,18 @@ importers:
 
   .:
     dependencies:
+      '@hono/node-server':
+        specifier: ^1.19.11
+        version: 1.19.11(hono@4.12.8)
       '@tanstack/react-router':
         specifier: ^1.0.0
         version: 1.167.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      acp-sdk:
+        specifier: ^1.0.3
+        version: 1.0.3
+      hono:
+        specifier: ^4.12.8
+        version: 4.12.8
       react:
         specifier: ^19.0.0
         version: 19.2.4
@@ -36,6 +45,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.0.0
         version: 4.7.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+      '@vitest/coverage-v8':
+        specifier: ^4.1.0
+        version: 4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))
       eslint:
         specifier: ^9.0.0
         version: 9.39.4(jiti@2.6.1)
@@ -69,6 +81,9 @@ importers:
       vite:
         specifier: ^6.0.0
         version: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
 
 packages:
 
@@ -154,6 +169,10 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@1.0.2':
+    resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -505,6 +524,12 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@hono/node-server@1.19.11':
+    resolution: {integrity: sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -536,6 +561,10 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -678,6 +707,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tailwindcss/node@4.2.1':
     resolution: {integrity: sha512-jlx6sLk4EOwO6hHe1oCGm1Q4AN/s0rSrTTPBGPM0/RQ6Uylwq17FuU8IeJJKEjtc6K6O07zsvP+gDO6MMWo7pg==}
 
@@ -809,6 +841,12 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -891,6 +929,44 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
+  '@vitest/coverage-v8@4.1.0':
+    resolution: {integrity: sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==}
+    peerDependencies:
+      '@vitest/browser': 4.1.0
+      vitest: 4.1.0
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
+  '@vitest/expect@4.1.0':
+    resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
+
+  '@vitest/mocker@4.1.0':
+    resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.0':
+    resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
+
+  '@vitest/runner@4.1.0':
+    resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
+
+  '@vitest/snapshot@4.1.0':
+    resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
+
+  '@vitest/spy@4.1.0':
+    resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
+
+  '@vitest/utils@4.1.0':
+    resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -901,6 +977,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  acp-sdk@1.0.3:
+    resolution: {integrity: sha512-AOP1bnIjUjNd+4FW76AdPjq5PPRFq6RIX8xdfd5Lg/+rd1z0BvbVovmBLxZE4jDekZFRH9wJlveynKXj9cf44A==}
+
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
@@ -910,6 +989,13 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
@@ -941,6 +1027,10 @@ packages:
 
   caniuse-lite@1.0.30001780:
     resolution: {integrity: sha512-llngX0E7nQci5BPJDqoZSbuZ5Bcs9F5db7EtgfwBerX9XGtkkiO4NwfDDIRzHTTwcYC8vC7bmeUEPGrKlR/TkQ==}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -991,6 +1081,9 @@ packages:
   enhanced-resolve@5.20.1:
     resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
     engines: {node: '>=10.13.0'}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -1063,9 +1156,20 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1131,6 +1235,13 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  hono@4.12.8:
+    resolution: {integrity: sha512-VJCEvtrezO1IAR+kqEYnxUOoStaQPGrCmX3j4wDTNOcD1uRPFpGlwQUIW8niPuvHXaTUxeOUl5MMDGrl+tmO9A==}
+    engines: {node: '>=16.9.0'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
@@ -1167,9 +1278,24 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1291,6 +1417,13 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
+
   minimatch@10.2.4:
     resolution: {integrity: sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==}
     engines: {node: 18 || 20 || >=22}
@@ -1311,6 +1444,9 @@ packages:
 
   node-releases@2.0.36:
     resolution: {integrity: sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
@@ -1335,6 +1471,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1415,9 +1554,18 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -1440,9 +1588,20 @@ packages:
   tiny-warning@1.0.3:
     resolution: {integrity: sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.0.4:
+    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
+    engines: {node: '>=14.0.0'}
 
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
@@ -1458,6 +1617,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@4.41.0:
+    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
+    engines: {node: '>=16'}
 
   typescript-eslint@8.57.1:
     resolution: {integrity: sha512-fLvZWf+cAGw3tqMCYzGIU6yR8K+Y9NT2z23RwOjlNFF2HwSB3KhdEFI5lSBv8tNmFkkBShSjsCjzx1vahZfISA==}
@@ -1487,6 +1650,10 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
 
   vite@6.4.1:
     resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
@@ -1528,9 +1695,49 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.0:
+    resolution: {integrity: sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.0
+      '@vitest/browser-preview': 4.1.0
+      '@vitest/browser-webdriverio': 4.1.0
+      '@vitest/ui': 4.1.0
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   word-wrap@1.2.5:
@@ -1543,6 +1750,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
 
@@ -1657,6 +1867,8 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@1.0.2': {}
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -1860,6 +2072,10 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@hono/node-server@1.19.11(hono@4.12.8)':
+    dependencies:
+      hono: 4.12.8
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -1889,6 +2105,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@opentelemetry/api@1.9.0': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -1966,6 +2184,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.59.0':
     optional: true
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@tailwindcss/node@4.2.1':
     dependencies:
@@ -2088,6 +2308,13 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -2207,11 +2434,74 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitest/coverage-v8@4.1.0(vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)))':
+    dependencies:
+      '@bcoe/v8-coverage': 1.0.2
+      '@vitest/utils': 4.1.0
+      ast-v8-to-istanbul: 1.0.0
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.0.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+
+  '@vitest/expect@4.1.0':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.1.0
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+
+  '@vitest/pretty-format@4.1.0':
+    dependencies:
+      tinyrainbow: 3.1.0
+
+  '@vitest/runner@4.1.0':
+    dependencies:
+      '@vitest/utils': 4.1.0
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.0':
+    dependencies:
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/utils': 4.1.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.0': {}
+
+  '@vitest/utils@4.1.0':
+    dependencies:
+      '@vitest/pretty-format': 4.1.0
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  acp-sdk@1.0.3:
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      eventsource-parser: 3.0.6
+      type-fest: 4.41.0
+      uuid: 11.1.0
+      zod: 3.25.76
 
   ajv@6.14.0:
     dependencies:
@@ -2225,6 +2515,14 @@ snapshots:
       color-convert: 2.0.1
 
   argparse@2.0.1: {}
+
+  assertion-error@2.0.1: {}
+
+  ast-v8-to-istanbul@1.0.0:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      estree-walker: 3.0.3
+      js-tokens: 10.0.0
 
   balanced-match@1.0.2: {}
 
@@ -2252,6 +2550,8 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001780: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -2292,6 +2592,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.0
+
+  es-module-lexer@2.0.0: {}
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -2431,7 +2733,15 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
+
+  eventsource-parser@3.0.6: {}
+
+  expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -2480,6 +2790,10 @@ snapshots:
 
   has-flag@4.0.0: {}
 
+  hono@4.12.8: {}
+
+  html-escaper@2.0.2: {}
+
   husky@9.1.7: {}
 
   ignore@5.3.2: {}
@@ -2503,7 +2817,22 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
   jiti@2.6.1: {}
+
+  js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -2593,6 +2922,16 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.4
+
   minimatch@10.2.4:
     dependencies:
       brace-expansion: 5.0.4
@@ -2608,6 +2947,8 @@ snapshots:
   natural-compare@1.4.0: {}
 
   node-releases@2.0.36: {}
+
+  obug@2.1.1: {}
 
   optionator@0.9.4:
     dependencies:
@@ -2633,6 +2974,8 @@ snapshots:
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -2712,7 +3055,13 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.0.0: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -2728,10 +3077,16 @@ snapshots:
 
   tiny-warning@1.0.3: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.0.4: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyrainbow@3.1.0: {}
 
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
@@ -2747,6 +3102,8 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@4.41.0: {}
 
   typescript-eslint@8.57.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3):
     dependencies:
@@ -2777,6 +3134,8 @@ snapshots:
     dependencies:
       react: 19.2.4
 
+  uuid@11.1.0: {}
+
   vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0):
     dependencies:
       esbuild: 0.25.12
@@ -2792,12 +3151,47 @@ snapshots:
       lightningcss: 1.31.1
       tsx: 4.21.0
 
+  vitest@4.1.0(@opentelemetry/api@1.9.0)(@types/node@22.19.15)(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.0
+      '@vitest/mocker': 4.1.0(vite@6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/runner': 4.1.0
+      '@vitest/snapshot': 4.1.0
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 6.4.1(@types/node@22.19.15)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 22.19.15
+    transitivePeerDependencies:
+      - msw
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   word-wrap@1.2.5: {}
 
   yallist@3.1.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@3.25.76: {}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['backend/src/**/*.test.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['lcov', 'text'],
+      include: ['backend/src/**'],
+      exclude: ['backend/src/**/*.test.ts'],
+    },
+  },
+})


### PR DESCRIPTION
## Summary

Implements issues #8 and #9.

### Issue #8 — Backend HTTP server scaffold
- Replaces the placeholder `backend/src/index.ts` with a real Hono server bound to `127.0.0.1:PORT` (ADR-012)
- `GET /health` → `{ status: 'ok' }`
- `GET /api/stream?sessionId=<id>` → SSE endpoint (AG-UI event channel) using Hono's `streamSSE()` (ADR-014)
- `pnpm build:backend` emits to `dist/backend/`
- Adds Vitest + V8 coverage, `pnpm test` / `pnpm test:coverage` scripts (ADR-015)
- Unit tests for the health route via `app.request()`

### Issue #9 — GitHub Copilot ACP adapter (reference implementation)
- `backend/src/adapters/copilot/` — full adapter following the pattern for all future adapters
- `CopilotProcess` — spawns the Copilot CLI as an ACP subprocess, discovers port from stdout
- `CopilotAdapter` — dependency-injected (factory pattern for testability); manages sessions, calls `client.runStream()`, emits translated AG-UI events on `EventEmitter`
- ACP → AG-UI translation: `message.part` (text) → `TEXT_MESSAGE_CONTENT`, tool-call → `TOOL_CALL_START`, tool-result → `TOOL_CALL_RESULT` (ADR-003)
- `mcpServers` from `mcp.json` injected as a structured `MessagePart` on the first ACP run per ADR-003
- Routes: `POST /api/agents/copilot/session/new`, `POST /api/agents/copilot/session/message`, `DELETE /api/agents/copilot/session/:id`
- 13 unit tests covering session lifecycle, event translation, and error paths
- Subprocess command configurable via `COPILOT_ACP_CMD` / `COPILOT_ACP_ARGS` env vars

closes #8
closes #9