### PR TITLE
feat: add Vite dev proxy for /api to backend

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,11 +2,21 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 
+const BACKEND_PORT = process.env['PORT'] ?? '3001'
+
 export default defineConfig({
   root: 'frontend',
   plugins: [tailwindcss(), react()],
   build: {
     outDir: '../dist/frontend',
     emptyOutDir: true,
+  },
+  server: {
+    proxy: {
+      '/api': {
+        target: `http://127.0.0.1:${BACKEND_PORT}`,
+        changeOrigin: false,
+      },
+    },
   },
 })


### PR DESCRIPTION
Forwards all `/api` requests from the Vite dev server (port 5173) to the Hono backend (default port 3001). The proxy target port is read from the `PORT` env var so it stays in sync with the backend.

With both `pnpm dev:frontend` and `pnpm dev:backend` running, the chat UI at `http://localhost:5173/chat` now reaches the backend without CORS issues.

closes #27