### PR TITLE
docs: add ADR-016 (multi-agent UX) and ADR-017 (project management)

### DIFF
--- a/docs/decisions/ADR-016-multi-agent-ux-model.md
+++ b/docs/decisions/ADR-016-multi-agent-ux-model.md
@@ -23,7 +23,7 @@ The backend already supports multiple simultaneous active agents (see ADR-003, A
 - **Agent status dot colors:**
   - Emerald (with glow) — `status === 'active'`
   - Amber — `status === 'detected'`
-  - Slate — any other status (`unavailable`, `missing`, etc.)
+  - Slate — any other status (`unavailable`, `detected` when not the primary color, etc.)
 - **Sessions from agents with `status === 'disabled'` are hidden.** Sessions from agents with any other non-active status (e.g. `unavailable`, `detected`) remain visible with their status dot shown.
 - **"New chat" button behavior:**
   - If exactly one active agent exists: clicking immediately creates a session with that agent.

--- a/docs/decisions/ADR-017-project-management.md
+++ b/docs/decisions/ADR-017-project-management.md
@@ -29,7 +29,7 @@ The backend already has a config file at `.acp/projects.json` (or `$ACP_PROJECTS
 
 ### Backend API mutations
 
-- **`POST /api/projects`** — adds a new project entry. Request body: `{ name: string, path: string }`. The backend resolves the path to absolute, derives an `id`, appends to the config, persists via `writeProjectConfig()`, and returns the new `ProjectSummary`.
+- **`POST /api/projects`** — adds a new project entry. Request body: `{ name: string, path: string }`. The `path` must be an absolute filesystem path; the backend rejects relative paths with 422. The backend derives an `id`, appends to the config, persists via `writeProjectConfig()`, and returns the new `ProjectSummary`.
 - **`DELETE /api/projects/:id`** — removes a project by ID, persists the change, returns 204.
 - No filesystem scanning or discovery endpoint is provided. Users supply the path explicitly.
 
@@ -46,7 +46,7 @@ The backend already has a config file at `.acp/projects.json` (or `$ACP_PROJECTS
 
 - The existing `<select>` dropdown in `ProjectWorkspacePanel` lists all projects from the backend (including `missing` and `invalid`), with non-available ones shown as disabled options.
 - A project with `status === 'missing'` or `status === 'invalid'` shows a warning badge in the panel body.
-- No inline delete UI is provided in this iteration; projects are removed by editing the config file directly.
+- No inline delete UI is provided in this iteration; projects can be removed via `DELETE /api/projects/:id` (API exists, no UI) or by editing the config file directly.
 
 ## Rejected Alternatives
 


### PR DESCRIPTION
## Summary

- **ADR-016** — Multi-agent UX model: concurrent agents, flat session list, status dots, role=menu picker, `ready` gated on session agent status
- **ADR-017** — Project management: `.acp/projects.json` format, `POST /api/projects` + `DELETE /api/projects/:id` API spec, inline add-project form UX

Both ADRs pass `node docs/decisions/validate-adrs.mjs`.

closes #42