### PR TITLE
feat: add OpenCode session history provider

### DIFF
--- a/backend/src/history/index.ts
+++ b/backend/src/history/index.ts
@@ -1,6 +1,7 @@
 import type { SessionProjectContext, SessionSummary } from '../agents/types.js'
 import { readCopilotSessions } from './copilot.js'
 import { readGeminiSessions } from './gemini.js'
+import { readOpenCodeSessions } from './opencode.js'
 
 interface HistorySessionProvider {
   id: string
@@ -15,6 +16,10 @@ const HISTORY_SESSION_PROVIDERS: HistorySessionProvider[] = [
   {
     id: 'copilot',
     readSessions: readCopilotSessions,
+  },
+  {
+    id: 'opencode',
+    readSessions: readOpenCodeSessions,
   },
 ]
 

--- a/backend/src/history/opencode.test.ts
+++ b/backend/src/history/opencode.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { readOpenCodeSessions } from './opencode.js'
+import * as fs from 'node:fs'
+import * as cp from 'node:child_process'
+import type { SessionProjectContext } from '../agents/types.js'
+
+vi.mock('node:fs')
+vi.mock('node:child_process')
+
+describe('readOpenCodeSessions', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(fs.existsSync).mockReturnValue(true)
+    vi.mocked(cp.execSync).mockReturnValue('')
+  })
+
+  it('returns empty array if db does not exist', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false)
+    expect(readOpenCodeSessions([])).toEqual([])
+  })
+
+  it('returns empty array if sqlite3 is not installed', () => {
+    vi.mocked(cp.execSync).mockImplementation((cmd) => {
+      if (typeof cmd === 'string' && cmd.includes('sqlite3 -version')) {
+        throw new Error('Command failed')
+      }
+      return ''
+    })
+    expect(readOpenCodeSessions([])).toEqual([])
+  })
+
+  it('parses sessions from sqlite output', () => {
+    const knownProjects: SessionProjectContext[] = [
+      { id: 'proj1', name: 'Proj 1', path: '/code/project1' },
+      { id: 'proj2', name: 'Proj 2', path: '/code/project2' },
+    ]
+
+    vi.mocked(cp.execSync).mockImplementation((cmd) => {
+      if (typeof cmd === 'string' && cmd.includes('sqlite3 -version')) {
+        return '3.43.2'
+      }
+      if (typeof cmd === 'string' && cmd.includes('sqlite3 -separator')) {
+        return [
+          'ses_1|||Fix auth bug|||1700000000000|||/code/project1',
+          'ses_2|||Add new feature|||1700000001000|||/code/project2',
+          'ses_unknown|||Unknown|||1700000002000|||/code/unknown',
+        ].join('\n')
+      }
+      return ''
+    })
+
+    const sessions = readOpenCodeSessions(knownProjects)
+
+    expect(sessions).toHaveLength(2)
+    expect(sessions[0]).toEqual({
+      id: 'ses_1',
+      title: 'Fix auth bug',
+      updatedAt: new Date(1700000000000).toISOString(),
+      agentId: 'opencode',
+      project: knownProjects[0],
+      source: 'history',
+    })
+    expect(sessions[1]).toEqual({
+      id: 'ses_2',
+      title: 'Add new feature',
+      updatedAt: new Date(1700000001000).toISOString(),
+      agentId: 'opencode',
+      project: knownProjects[1],
+      source: 'history',
+    })
+  })
+
+  it('handles empty database output', () => {
+    vi.mocked(cp.execSync).mockImplementation(() => '')
+    expect(readOpenCodeSessions([{ id: 'p', name: 'P', path: '/code' }])).toEqual([])
+  })
+})

--- a/backend/src/history/opencode.ts
+++ b/backend/src/history/opencode.ts
@@ -1,0 +1,93 @@
+/**
+ * Reads OpenCode session history from the local SQLite database.
+ *
+ * OpenCode stores its application state in an SQLite database at:
+ *   ~/.local/share/opencode/opencode.db
+ *
+ * We query the `session` and `project` tables to extract session metadata
+ * and map it to our internal project representations.
+ */
+
+import { execSync } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import type { SessionProjectContext, SessionSummary } from '../agents/types.js'
+
+const OPENCODE_DB_PATH =
+  process.env['OPENCODE_DB_PATH'] ?? join(homedir(), '.local', 'share', 'opencode', 'opencode.db')
+
+const OPENCODE_AGENT_ID = 'opencode'
+
+export function readOpenCodeSessions(knownProjects: SessionProjectContext[]): SessionSummary[] {
+  if (!existsSync(OPENCODE_DB_PATH)) {
+    return []
+  }
+
+  // Ensure sqlite3 is available in PATH
+  try {
+    execSync('sqlite3 -version', { stdio: 'ignore' })
+  } catch {
+    return []
+  }
+
+  // Query sessions joined with projects to get the worktree path
+  const query = `
+    SELECT 
+      s.id, 
+      s.title, 
+      s.time_updated, 
+      p.worktree 
+    FROM session s 
+    JOIN project p ON s.project_id = p.id;
+  `
+
+  let stdout: string
+  try {
+    // Execute query and output as tab-separated values (sqlite3 default for raw output is pipe-separated, we use -separator to be explicit)
+    stdout = execSync(`sqlite3 -separator '|||' "${OPENCODE_DB_PATH}" "${query}"`, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+  } catch {
+    return []
+  }
+
+  const results: SessionSummary[] = []
+  const lines = stdout.split('\n')
+
+  for (const line of lines) {
+    if (!line.trim()) continue
+
+    const parts = line.split('|||')
+    if (parts.length < 4) continue
+
+    const [id, title, timeUpdatedStr, worktree] = parts
+
+    // OpenCode time_updated is in milliseconds
+    const timeUpdated = parseInt(timeUpdatedStr ?? '0', 10)
+    if (isNaN(timeUpdated) || timeUpdated === 0) continue
+
+    const project = resolveProject(worktree ?? '', knownProjects)
+    if (!project) continue
+
+    results.push({
+      id: id ?? '',
+      title: title ?? 'OpenCode session',
+      updatedAt: new Date(timeUpdated).toISOString(),
+      agentId: OPENCODE_AGENT_ID,
+      project,
+      source: 'history',
+    })
+  }
+
+  return results
+}
+
+function resolveProject(
+  projectPath: string,
+  knownProjects: SessionProjectContext[]
+): SessionProjectContext | null {
+  const normalized = projectPath.replace(/\/+$/, '')
+  return knownProjects.find((project) => project.path.replace(/\/+$/, '') === normalized) ?? null
+}


### PR DESCRIPTION
Resolves #58

## Summary
- Reads local SQLite database at `~/.local/share/opencode/opencode.db` via child_process `sqlite3` so we don't need to add new native node modules
- Maps `time_updated` and `worktree` columns to our `SessionSummary` format
- Adds unit tests and wires it into the main `HistorySessionProvider` registry