### PR TITLE
feat: formalise mcp.json config loading

### DIFF
--- a/backend/src/mcp.test.ts
+++ b/backend/src/mcp.test.ts
@@ -1,0 +1,159 @@
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const envKey = 'ACP_MCP_CONFIG_PATH'
+
+afterEach(() => {
+  vi.resetModules()
+  delete process.env[envKey]
+})
+
+function tempConfigPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'acp-mcp-'))
+  return join(dir, 'mcp.json')
+}
+
+async function loadMcpServers() {
+  const { loadMcpServers: fn } = await import('./mcp.js')
+  return fn()
+}
+
+describe('loadMcpServers', () => {
+  it('returns empty array when config file is missing', async () => {
+    process.env[envKey] = join(tmpdir(), 'nonexistent-acp-mcp', 'mcp.json')
+    const servers = await loadMcpServers()
+    expect(servers).toEqual([])
+  })
+
+  it('returns empty array when file contains invalid JSON', async () => {
+    const path = tempConfigPath()
+    writeFileSync(path, 'not json at all')
+    process.env[envKey] = path
+
+    const servers = await loadMcpServers()
+    expect(servers).toEqual([])
+  })
+
+  it('returns empty array when top-level value is not an object', async () => {
+    const path = tempConfigPath()
+    writeFileSync(path, JSON.stringify([{ name: 'bad' }]))
+    process.env[envKey] = path
+
+    const servers = await loadMcpServers()
+    expect(servers).toEqual([])
+  })
+
+  it('returns empty array when mcpServers is an array instead of object', async () => {
+    const path = tempConfigPath()
+    writeFileSync(path, JSON.stringify({ mcpServers: ['bad'] }))
+    process.env[envKey] = path
+
+    const servers = await loadMcpServers()
+    expect(servers).toEqual([])
+  })
+
+  it('returns empty array when mcpServers key is missing', async () => {
+    const path = tempConfigPath()
+    writeFileSync(path, JSON.stringify({}))
+    process.env[envKey] = path
+
+    const servers = await loadMcpServers()
+    expect(servers).toEqual([])
+  })
+
+  it('returns empty array when mcpServers is an empty object', async () => {
+    const path = tempConfigPath()
+    writeFileSync(path, JSON.stringify({ mcpServers: {} }))
+    process.env[envKey] = path
+
+    const servers = await loadMcpServers()
+    expect(servers).toEqual([])
+  })
+
+  it('returns a single server with only command (minimal entry)', async () => {
+    const path = tempConfigPath()
+    writeFileSync(
+      path,
+      JSON.stringify({
+        mcpServers: {
+          myTool: { command: 'my-tool' },
+        },
+      })
+    )
+    process.env[envKey] = path
+
+    const servers = await loadMcpServers()
+    expect(servers).toEqual([{ name: 'myTool', command: 'my-tool', args: [], env: [] }])
+  })
+
+  it('maps args and env correctly for a full entry', async () => {
+    const path = tempConfigPath()
+    writeFileSync(
+      path,
+      JSON.stringify({
+        mcpServers: {
+          fullTool: {
+            command: 'full-tool',
+            args: ['--verbose', '--output=json'],
+            env: { API_KEY: 'secret', REGION: 'us-east-1' },
+          },
+        },
+      })
+    )
+    process.env[envKey] = path
+
+    const servers = await loadMcpServers()
+    expect(servers).toEqual([
+      {
+        name: 'fullTool',
+        command: 'full-tool',
+        args: ['--verbose', '--output=json'],
+        env: [
+          { name: 'API_KEY', value: 'secret' },
+          { name: 'REGION', value: 'us-east-1' },
+        ],
+      },
+    ])
+  })
+
+  it('returns multiple servers preserving all entries', async () => {
+    const path = tempConfigPath()
+    writeFileSync(
+      path,
+      JSON.stringify({
+        mcpServers: {
+          toolA: { command: 'tool-a' },
+          toolB: { command: 'tool-b', args: ['--flag'] },
+        },
+      })
+    )
+    process.env[envKey] = path
+
+    const servers = await loadMcpServers()
+    expect(servers).toHaveLength(2)
+    expect(servers).toEqual(
+      expect.arrayContaining([
+        { name: 'toolA', command: 'tool-a', args: [], env: [] },
+        { name: 'toolB', command: 'tool-b', args: ['--flag'], env: [] },
+      ])
+    )
+  })
+
+  it('respects ACP_MCP_CONFIG_PATH env override', async () => {
+    const path = tempConfigPath()
+    writeFileSync(
+      path,
+      JSON.stringify({
+        mcpServers: {
+          envOverrideTool: { command: 'env-tool' },
+        },
+      })
+    )
+    process.env[envKey] = path
+
+    const servers = await loadMcpServers()
+    expect(servers).toEqual([{ name: 'envOverrideTool', command: 'env-tool', args: [], env: [] }])
+  })
+})

--- a/backend/src/mcp.ts
+++ b/backend/src/mcp.ts
@@ -1,33 +1,61 @@
-import { readFileSync, existsSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { join } from 'node:path'
 import type { McpServer } from '@agentclientprotocol/sdk'
 
-interface McpServerConfig {
+export interface McpServerConfig {
   command: string
   args?: string[]
   env?: Record<string, string>
 }
 
-interface McpConfig {
-  mcpServers: Record<string, McpServerConfig>
+export interface McpConfig {
+  mcpServers?: Record<string, McpServerConfig>
 }
 
-const MCP_JSON_PATH = process.env['MCP_JSON_PATH'] ?? join(process.cwd(), 'mcp.json')
+const MCP_CONFIG_PATH =
+  process.env['ACP_MCP_CONFIG_PATH'] ?? join(process.cwd(), '.acp', 'mcp.json')
+
+function readMcpConfigFile(): McpConfig | null {
+  if (!existsSync(MCP_CONFIG_PATH)) {
+    return null
+  }
+
+  try {
+    const raw = readFileSync(MCP_CONFIG_PATH, 'utf8')
+    const parsed = JSON.parse(raw) as unknown
+
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return null
+    }
+
+    const config = parsed as Record<string, unknown>
+
+    if (
+      'mcpServers' in config &&
+      (typeof config['mcpServers'] !== 'object' ||
+        config['mcpServers'] === null ||
+        Array.isArray(config['mcpServers']))
+    ) {
+      return null
+    }
+
+    return config as McpConfig
+  } catch {
+    return null
+  }
+}
 
 export function loadMcpServers(): McpServer[] {
-  if (!existsSync(MCP_JSON_PATH)) {
+  const config = readMcpConfigFile()
+
+  if (!config) {
     return []
   }
-  try {
-    const raw = readFileSync(MCP_JSON_PATH, 'utf8')
-    const config = JSON.parse(raw) as McpConfig
-    return Object.entries(config.mcpServers ?? {}).map(([name, server]) => ({
-      name,
-      command: server.command,
-      args: server.args ?? [],
-      env: Object.entries(server.env ?? {}).map(([envName, value]) => ({ name: envName, value })),
-    }))
-  } catch {
-    return []
-  }
+
+  return Object.entries(config.mcpServers ?? {}).map(([name, server]) => ({
+    name,
+    command: server.command,
+    args: server.args ?? [],
+    env: Object.entries(server.env ?? {}).map(([envName, value]) => ({ name: envName, value })),
+  }))
 }


### PR DESCRIPTION
## Summary

- Export `McpServerConfig` and `McpConfig` TypeScript types from `backend/src/mcp.ts`
- Change default config path from `cwd/mcp.json` → `cwd/.acp/mcp.json` to match the established pattern used by `projects/config.ts` and `agents/config.ts`
- Rename env override var from `MCP_JSON_PATH` → `ACP_MCP_CONFIG_PATH` for consistency with `ACP_PROJECTS_CONFIG_PATH` and `ACP_BACKENDS_CONFIG_PATH`
- Add validation: reject configs where `mcpServers` is an array or other non-object value
- Add `backend/src/mcp.test.ts` with 10 unit tests covering: missing file, invalid JSON, wrong top-level type, array `mcpServers`, missing `mcpServers` key, empty `mcpServers`, minimal entry, full entry with args+env, multiple servers, env var override

Closes #16