### PR TITLE
fix: resolve history session 404s and bootstrap connecting-chip loop

### DIFF
--- a/backend/src/agents/registry.ts
+++ b/backend/src/agents/registry.ts
@@ -23,7 +23,7 @@ import { StdioAcpProcess } from '../adapters/shared/process.js'
 import { deriveEndpointSupport } from '../adapters/shared/capabilities.js'
 import type { SessionProjectContext } from './types.js'
 import { listProjects, toSessionProjectContext } from '../projects/service.js'
-import { listHistorySessions, mergeSessions } from '../history/index.js'
+import { listHistorySessions, mergeSessions, getHistorySession } from '../history/index.js'
 
 interface RegisteredAgent {
   id: string
@@ -214,7 +214,8 @@ export class AgentRegistry {
       if (session) return session
     }
 
-    return null
+    const knownProjects = listProjects().map(toSessionProjectContext)
+    return getHistorySession(sessionId, knownProjects)
   }
 
   async sendMessage(sessionId: string, text: string, agentId?: string): Promise<void> {

--- a/backend/src/history/copilot.test.ts
+++ b/backend/src/history/copilot.test.ts
@@ -125,3 +125,116 @@ describe('readCopilotSessions', () => {
     expect(readCopilotSessions(knownProjects)).toEqual([])
   })
 })
+
+describe('getCopilotSession', () => {
+  it('returns full session details with messages for a known session id', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'acp-copilot-history-'))
+    const sessionDir = join(tempDir, 'session-detail-1')
+    mkdirSync(sessionDir, { recursive: true })
+
+    writeFileSync(
+      join(sessionDir, 'workspace.yaml'),
+      [
+        'id: session-detail-1',
+        'cwd: /work/acp-frontend',
+        'created_at: 2026-03-20T08:00:00.000Z',
+        'updated_at: 2026-03-20T08:30:00.000Z',
+        'summary: Detail session',
+        '',
+      ].join('\n')
+    )
+
+    writeFileSync(
+      join(sessionDir, 'events.jsonl'),
+      [
+        JSON.stringify({ type: 'session.start', data: { sessionId: 'session-detail-1' } }),
+        JSON.stringify({
+          id: 'msg-u-1',
+          type: 'user.message',
+          data: { content: 'What is a hook?' },
+        }),
+        JSON.stringify({
+          id: 'msg-a-1',
+          type: 'assistant.message',
+          data: { content: 'A hook is a function that...' },
+        }),
+        '',
+      ].join('\n')
+    )
+
+    process.env[envKey] = tempDir
+    const { getCopilotSession } = await import('./copilot.js')
+
+    const knownProjects: SessionProjectContext[] = [
+      { id: 'repo-1', name: 'ACP Frontend', path: '/work/acp-frontend' },
+    ]
+
+    expect(getCopilotSession('session-detail-1', knownProjects)).toEqual({
+      id: 'session-detail-1',
+      title: 'Detail session',
+      updatedAt: '2026-03-20T08:30:00.000Z',
+      agentId: 'copilot',
+      project: { id: 'repo-1', name: 'ACP Frontend', path: '/work/acp-frontend' },
+      source: 'history',
+      messages: [
+        { id: 'msg-u-1', role: 'user', content: 'What is a hook?' },
+        { id: 'msg-a-1', role: 'assistant', content: 'A hook is a function that...' },
+      ],
+    })
+  })
+
+  it('returns null when the session id is not found', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'acp-copilot-history-'))
+    const sessionDir = join(tempDir, 'session-other')
+    mkdirSync(sessionDir, { recursive: true })
+
+    writeFileSync(
+      join(sessionDir, 'workspace.yaml'),
+      [
+        'id: session-other',
+        'cwd: /work/acp-frontend',
+        'created_at: 2026-03-20T08:00:00.000Z',
+        'updated_at: 2026-03-20T08:30:00.000Z',
+        '',
+      ].join('\n')
+    )
+
+    process.env[envKey] = tempDir
+    const { getCopilotSession } = await import('./copilot.js')
+
+    const knownProjects: SessionProjectContext[] = [
+      { id: 'repo-1', name: 'ACP Frontend', path: '/work/acp-frontend' },
+    ]
+
+    expect(getCopilotSession('session-not-found', knownProjects)).toBeNull()
+  })
+
+  it('returns empty messages when events.jsonl is absent', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'acp-copilot-history-'))
+    const sessionDir = join(tempDir, 'session-no-events')
+    mkdirSync(sessionDir, { recursive: true })
+
+    writeFileSync(
+      join(sessionDir, 'workspace.yaml'),
+      [
+        'id: session-no-events',
+        'cwd: /work/acp-frontend',
+        'created_at: 2026-03-20T09:00:00.000Z',
+        'updated_at: 2026-03-20T09:05:00.000Z',
+        'summary: No events yet',
+        '',
+      ].join('\n')
+    )
+
+    process.env[envKey] = tempDir
+    const { getCopilotSession } = await import('./copilot.js')
+
+    const knownProjects: SessionProjectContext[] = [
+      { id: 'repo-1', name: 'ACP Frontend', path: '/work/acp-frontend' },
+    ]
+
+    const result = getCopilotSession('session-no-events', knownProjects)
+    expect(result).not.toBeNull()
+    expect(result?.messages).toEqual([])
+  })
+})

--- a/backend/src/history/copilot.ts
+++ b/backend/src/history/copilot.ts
@@ -1,7 +1,12 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
-import type { SessionProjectContext, SessionSummary } from '../agents/types.js'
+import type {
+  SessionDetails,
+  SessionMessage,
+  SessionProjectContext,
+  SessionSummary,
+} from '../agents/types.js'
 
 interface CopilotWorkspaceMeta {
   id?: string
@@ -16,6 +21,12 @@ interface CopilotUserMessageEvent {
   data?: {
     content?: string
   }
+}
+
+interface CopilotAnyEvent {
+  type: string
+  id?: string
+  data?: Record<string, unknown>
 }
 
 const COPILOT_SESSION_STATE_DIR =
@@ -73,6 +84,92 @@ export function readCopilotSessions(knownProjects: SessionProjectContext[]): Ses
   }
 
   return results
+}
+
+export function getCopilotSession(
+  sessionId: string,
+  knownProjects: SessionProjectContext[]
+): SessionDetails | null {
+  if (!existsSync(COPILOT_SESSION_STATE_DIR)) {
+    return null
+  }
+
+  let sessionDirs: string[]
+  try {
+    sessionDirs = readdirSync(COPILOT_SESSION_STATE_DIR, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+  } catch {
+    return null
+  }
+
+  for (const dir of sessionDirs) {
+    const workspaceFile = join(COPILOT_SESSION_STATE_DIR, dir, 'workspace.yaml')
+    if (!existsSync(workspaceFile)) continue
+
+    const metadata = readWorkspaceMetadata(workspaceFile)
+    if (!metadata.cwd) continue
+
+    const effectiveId = metadata.id ?? dir
+    if (effectiveId !== sessionId) continue
+
+    const project = resolveProject(metadata.cwd, knownProjects)
+    if (!project) continue
+
+    const updatedAt = metadata.updated_at ?? metadata.created_at
+    if (!updatedAt) continue
+
+    const title = deriveTitle(dir, metadata)
+    const messages = readSessionMessages(dir)
+
+    return {
+      id: sessionId,
+      title,
+      updatedAt,
+      agentId: COPILOT_AGENT_ID,
+      project,
+      source: 'history',
+      messages,
+    }
+  }
+
+  return null
+}
+
+function readSessionMessages(sessionDir: string): SessionMessage[] {
+  const eventsFile = join(COPILOT_SESSION_STATE_DIR, sessionDir, 'events.jsonl')
+  if (!existsSync(eventsFile)) return []
+
+  const messages: SessionMessage[] = []
+
+  try {
+    const raw = readFileSync(eventsFile, 'utf8')
+    let messageIndex = 0
+
+    for (const line of raw.split(/\r?\n/)) {
+      if (!line.trim()) continue
+
+      const event = JSON.parse(line) as CopilotAnyEvent
+
+      if (event.type === 'user.message') {
+        const content = (event.data?.['content'] as string | undefined)?.trim()
+        if (content) {
+          messages.push({ id: event.id ?? `user-${messageIndex}`, role: 'user', content })
+          messageIndex++
+        }
+      } else if (event.type === 'assistant.message') {
+        const content = (event.data?.['content'] as string | undefined)?.trim()
+        if (content) {
+          messages.push({ id: event.id ?? `assistant-${messageIndex}`, role: 'assistant', content })
+          messageIndex++
+        }
+      }
+    }
+  } catch {
+    return messages
+  }
+
+  return messages
 }
 
 function readWorkspaceMetadata(filePath: string): CopilotWorkspaceMeta {

--- a/backend/src/history/gemini.test.ts
+++ b/backend/src/history/gemini.test.ts
@@ -1,0 +1,195 @@
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { SessionProjectContext } from '../agents/types.js'
+
+const envKey = 'GEMINI_TMP_DIR'
+
+afterEach(() => {
+  vi.resetModules()
+  delete process.env[envKey]
+})
+
+describe('readGeminiSessions', () => {
+  it('returns sessions matching a known project', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'acp-gemini-history-'))
+    const projectDir = join(tempDir, 'work-acp-frontend')
+    const chatsDir = join(projectDir, 'chats')
+    mkdirSync(chatsDir, { recursive: true })
+
+    writeFileSync(join(projectDir, '.project_root'), '/work/acp-frontend\n')
+
+    const session = {
+      sessionId: 'gemini-abc-123',
+      startTime: '2026-03-19T10:00:00.000Z',
+      lastUpdated: '2026-03-19T10:30:00.000Z',
+      messages: [
+        {
+          id: 'msg-1',
+          timestamp: '2026-03-19T10:00:05.000Z',
+          type: 'user',
+          content: 'Hello Gemini',
+        },
+      ],
+    }
+    writeFileSync(join(chatsDir, 'session-123.json'), JSON.stringify(session))
+
+    process.env[envKey] = tempDir
+    const { readGeminiSessions } = await import('./gemini.js')
+
+    const knownProjects: SessionProjectContext[] = [
+      { id: 'repo-1', name: 'ACP Frontend', path: '/work/acp-frontend' },
+    ]
+
+    expect(readGeminiSessions(knownProjects)).toEqual([
+      {
+        id: 'gemini-abc-123',
+        title: 'Hello Gemini',
+        updatedAt: '2026-03-19T10:30:00.000Z',
+        agentId: 'gemini-cli',
+        project: { id: 'repo-1', name: 'ACP Frontend', path: '/work/acp-frontend' },
+        source: 'history',
+      },
+    ])
+  })
+
+  it('ignores sessions that do not match a known project', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'acp-gemini-history-'))
+    const projectDir = join(tempDir, 'work-other')
+    const chatsDir = join(projectDir, 'chats')
+    mkdirSync(chatsDir, { recursive: true })
+
+    writeFileSync(join(projectDir, '.project_root'), '/work/other\n')
+    writeFileSync(
+      join(chatsDir, 'session-999.json'),
+      JSON.stringify({
+        sessionId: 'gemini-other',
+        startTime: '2026-03-19T10:00:00.000Z',
+        messages: [],
+      })
+    )
+
+    process.env[envKey] = tempDir
+    const { readGeminiSessions } = await import('./gemini.js')
+
+    const knownProjects: SessionProjectContext[] = [
+      { id: 'repo-1', name: 'ACP Frontend', path: '/work/acp-frontend' },
+    ]
+
+    expect(readGeminiSessions(knownProjects)).toEqual([])
+  })
+})
+
+describe('getGeminiSession', () => {
+  it('returns full session details including messages for a known session id', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'acp-gemini-history-'))
+    const projectDir = join(tempDir, 'work-acp-frontend')
+    const chatsDir = join(projectDir, 'chats')
+    mkdirSync(chatsDir, { recursive: true })
+
+    writeFileSync(join(projectDir, '.project_root'), '/work/acp-frontend\n')
+
+    const session = {
+      sessionId: 'gemini-detail-1',
+      startTime: '2026-03-20T08:00:00.000Z',
+      lastUpdated: '2026-03-20T08:15:00.000Z',
+      messages: [
+        {
+          id: 'u-1',
+          timestamp: '2026-03-20T08:00:01.000Z',
+          type: 'user',
+          content: 'Explain useEffect',
+        },
+        {
+          id: 'a-1',
+          timestamp: '2026-03-20T08:00:05.000Z',
+          type: 'gemini',
+          content: 'useEffect runs side-effects',
+        },
+        { id: 'u-2', timestamp: '2026-03-20T08:01:00.000Z', type: 'user', content: 'Thanks' },
+      ],
+    }
+    writeFileSync(join(chatsDir, 'session-detail-1.json'), JSON.stringify(session))
+
+    process.env[envKey] = tempDir
+    const { getGeminiSession } = await import('./gemini.js')
+
+    const knownProjects: SessionProjectContext[] = [
+      { id: 'repo-1', name: 'ACP Frontend', path: '/work/acp-frontend' },
+    ]
+
+    expect(getGeminiSession('gemini-detail-1', knownProjects)).toEqual({
+      id: 'gemini-detail-1',
+      title: 'Explain useEffect',
+      updatedAt: '2026-03-20T08:15:00.000Z',
+      agentId: 'gemini-cli',
+      project: { id: 'repo-1', name: 'ACP Frontend', path: '/work/acp-frontend' },
+      source: 'history',
+      messages: [
+        { id: 'u-1', role: 'user', content: 'Explain useEffect' },
+        { id: 'a-1', role: 'assistant', content: 'useEffect runs side-effects' },
+        { id: 'u-2', role: 'user', content: 'Thanks' },
+      ],
+    })
+  })
+
+  it('returns null when the session id is not found', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'acp-gemini-history-'))
+    const projectDir = join(tempDir, 'work-acp-frontend')
+    const chatsDir = join(projectDir, 'chats')
+    mkdirSync(chatsDir, { recursive: true })
+
+    writeFileSync(join(projectDir, '.project_root'), '/work/acp-frontend\n')
+    writeFileSync(
+      join(chatsDir, 'session-xyz.json'),
+      JSON.stringify({
+        sessionId: 'gemini-xyz',
+        startTime: '2026-03-20T08:00:00.000Z',
+        messages: [],
+      })
+    )
+
+    process.env[envKey] = tempDir
+    const { getGeminiSession } = await import('./gemini.js')
+
+    const knownProjects: SessionProjectContext[] = [
+      { id: 'repo-1', name: 'ACP Frontend', path: '/work/acp-frontend' },
+    ]
+
+    expect(getGeminiSession('gemini-not-found', knownProjects)).toBeNull()
+  })
+
+  it('maps ContentPart arrays to plain text', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'acp-gemini-history-'))
+    const projectDir = join(tempDir, 'work-acp-frontend')
+    const chatsDir = join(projectDir, 'chats')
+    mkdirSync(chatsDir, { recursive: true })
+
+    writeFileSync(join(projectDir, '.project_root'), '/work/acp-frontend\n')
+
+    const session = {
+      sessionId: 'gemini-parts-1',
+      startTime: '2026-03-21T09:00:00.000Z',
+      messages: [
+        {
+          id: 'u-1',
+          timestamp: '2026-03-21T09:00:01.000Z',
+          type: 'user',
+          content: [{ text: 'Hello' }, { text: ' world' }],
+        },
+      ],
+    }
+    writeFileSync(join(chatsDir, 'session-parts-1.json'), JSON.stringify(session))
+
+    process.env[envKey] = tempDir
+    const { getGeminiSession } = await import('./gemini.js')
+
+    const knownProjects: SessionProjectContext[] = [
+      { id: 'repo-1', name: 'ACP Frontend', path: '/work/acp-frontend' },
+    ]
+
+    const result = getGeminiSession('gemini-parts-1', knownProjects)
+    expect(result?.messages).toEqual([{ id: 'u-1', role: 'user', content: 'Hello world' }])
+  })
+})

--- a/backend/src/history/gemini.ts
+++ b/backend/src/history/gemini.ts
@@ -18,7 +18,12 @@
 import { existsSync, readdirSync, readFileSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
-import type { SessionSummary, SessionProjectContext } from '../agents/types.js'
+import type {
+  SessionDetails,
+  SessionMessage,
+  SessionSummary,
+  SessionProjectContext,
+} from '../agents/types.js'
 
 interface GeminiContentPart {
   text?: string
@@ -108,6 +113,73 @@ export function readGeminiSessions(knownProjects: SessionProjectContext[]): Sess
   }
 
   return results
+}
+
+/**
+ * Return full session details (including messages) for a specific Gemini session ID.
+ * Scans all project dirs to find the matching session file.
+ */
+export function getGeminiSession(
+  sessionId: string,
+  knownProjects: SessionProjectContext[]
+): SessionDetails | null {
+  if (!existsSync(GEMINI_TMP_DIR)) {
+    return null
+  }
+
+  let projectDirs: string[]
+  try {
+    projectDirs = readdirSync(GEMINI_TMP_DIR, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+  } catch {
+    return null
+  }
+
+  for (const dir of projectDirs) {
+    const projectRootFile = join(GEMINI_TMP_DIR, dir, '.project_root')
+    if (!existsSync(projectRootFile)) continue
+
+    const projectPath = readProjectRoot(projectRootFile)
+    if (!projectPath) continue
+
+    const project = resolveProject(projectPath, knownProjects)
+    if (!project) continue
+
+    const chatsDir = join(GEMINI_TMP_DIR, dir, 'chats')
+    if (!existsSync(chatsDir)) continue
+
+    let sessionFiles: string[]
+    try {
+      sessionFiles = readdirSync(chatsDir).filter((name) => name.endsWith('.json'))
+    } catch {
+      continue
+    }
+
+    for (const file of sessionFiles) {
+      const session = parseGeminiSession(join(chatsDir, file))
+      if (!session || session.sessionId !== sessionId) continue
+
+      const messages: SessionMessage[] = (session.messages ?? []).flatMap((m) => {
+        const role: 'user' | 'assistant' = m.type === 'user' ? 'user' : 'assistant'
+        const content = extractText(m.content)
+        if (!content.trim()) return []
+        return [{ id: m.id, role, content }]
+      })
+
+      return {
+        id: session.sessionId,
+        title: deriveTitle(session),
+        updatedAt: session.lastUpdated ?? session.startTime,
+        agentId: GEMINI_AGENT_ID,
+        project,
+        source: 'history',
+        messages,
+      }
+    }
+  }
+
+  return null
 }
 
 function readProjectRoot(filePath: string): string | null {

--- a/backend/src/history/index.ts
+++ b/backend/src/history/index.ts
@@ -1,25 +1,29 @@
-import type { SessionProjectContext, SessionSummary } from '../agents/types.js'
-import { readCopilotSessions } from './copilot.js'
-import { readGeminiSessions } from './gemini.js'
-import { readOpenCodeSessions } from './opencode.js'
+import type { SessionDetails, SessionProjectContext, SessionSummary } from '../agents/types.js'
+import { readCopilotSessions, getCopilotSession } from './copilot.js'
+import { readGeminiSessions, getGeminiSession } from './gemini.js'
+import { readOpenCodeSessions, getOpenCodeSession } from './opencode.js'
 
 interface HistorySessionProvider {
   id: string
   readSessions: (knownProjects: SessionProjectContext[]) => SessionSummary[]
+  getSession: (sessionId: string, knownProjects: SessionProjectContext[]) => SessionDetails | null
 }
 
 const HISTORY_SESSION_PROVIDERS: HistorySessionProvider[] = [
   {
     id: 'gemini-cli',
     readSessions: readGeminiSessions,
+    getSession: getGeminiSession,
   },
   {
     id: 'copilot',
     readSessions: readCopilotSessions,
+    getSession: getCopilotSession,
   },
   {
     id: 'opencode',
     readSessions: readOpenCodeSessions,
+    getSession: getOpenCodeSession,
   },
 ]
 
@@ -28,6 +32,17 @@ export function listHistorySessions(knownProjects: SessionProjectContext[]): Ses
     provider.readSessions(knownProjects)
   )
   return dedupeSessions(sessions)
+}
+
+export function getHistorySession(
+  sessionId: string,
+  knownProjects: SessionProjectContext[]
+): SessionDetails | null {
+  for (const provider of HISTORY_SESSION_PROVIDERS) {
+    const session = provider.getSession(sessionId, knownProjects)
+    if (session) return session
+  }
+  return null
 }
 
 export function mergeSessions(

--- a/backend/src/history/opencode.test.ts
+++ b/backend/src/history/opencode.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { readOpenCodeSessions } from './opencode.js'
+import { readOpenCodeSessions, getOpenCodeSession } from './opencode.js'
 import * as fs from 'node:fs'
 import * as cp from 'node:child_process'
 import type { SessionProjectContext } from '../agents/types.js'
@@ -73,5 +73,92 @@ describe('readOpenCodeSessions', () => {
   it('handles empty database output', () => {
     vi.mocked(cp.execSync).mockImplementation(() => '')
     expect(readOpenCodeSessions([{ id: 'p', name: 'P', path: '/code' }])).toEqual([])
+  })
+})
+
+describe('getOpenCodeSession', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    vi.mocked(fs.existsSync).mockReturnValue(true)
+    vi.mocked(cp.execSync).mockReturnValue('')
+  })
+
+  it('returns null if db does not exist', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(false)
+    expect(getOpenCodeSession('ses_1', [])).toBeNull()
+  })
+
+  it('returns null if sqlite3 is not installed', () => {
+    vi.mocked(cp.execSync).mockImplementation((cmd) => {
+      if (typeof cmd === 'string' && cmd.includes('sqlite3 -version')) {
+        throw new Error('Command failed')
+      }
+      return ''
+    })
+    expect(getOpenCodeSession('ses_1', [])).toBeNull()
+  })
+
+  it('returns null when the session is not found in the database', () => {
+    vi.mocked(cp.execSync).mockImplementation((cmd) => {
+      if (typeof cmd === 'string' && cmd.includes('sqlite3 -version')) return '3.43.2'
+      return ''
+    })
+    expect(getOpenCodeSession('ses_missing', [{ id: 'p', name: 'P', path: '/code' }])).toBeNull()
+  })
+
+  it('returns full session details with messages', () => {
+    const knownProjects: SessionProjectContext[] = [
+      { id: 'proj1', name: 'Proj 1', path: '/code/project1' },
+    ]
+
+    vi.mocked(cp.execSync).mockImplementation((cmd) => {
+      if (typeof cmd === 'string' && cmd.includes('sqlite3 -version')) return '3.43.2'
+      if (typeof cmd === 'string' && cmd.includes('ses_detail')) {
+        // First query: metadata
+        if (cmd.includes('JOIN project')) {
+          return 'ses_detail|||Fix the bug|||1700000000000|||/code/project1\n'
+        }
+        // Second query: messages
+        return [
+          'msg-1|||user|||What is wrong?',
+          'msg-2|||assistant|||The issue is in line 42.',
+        ].join('\n')
+      }
+      return ''
+    })
+
+    expect(getOpenCodeSession('ses_detail', knownProjects)).toEqual({
+      id: 'ses_detail',
+      title: 'Fix the bug',
+      updatedAt: new Date(1700000000000).toISOString(),
+      agentId: 'opencode',
+      project: knownProjects[0],
+      source: 'history',
+      messages: [
+        { id: 'msg-1', role: 'user', content: 'What is wrong?' },
+        { id: 'msg-2', role: 'assistant', content: 'The issue is in line 42.' },
+      ],
+    })
+  })
+
+  it('returns session with empty messages when no message rows are returned', () => {
+    const knownProjects: SessionProjectContext[] = [
+      { id: 'proj1', name: 'Proj 1', path: '/code/project1' },
+    ]
+
+    let callCount = 0
+    vi.mocked(cp.execSync).mockImplementation((cmd) => {
+      if (typeof cmd === 'string' && cmd.includes('sqlite3 -version')) return '3.43.2'
+      if (typeof cmd === 'string' && cmd.includes('sqlite3 -separator')) {
+        callCount++
+        if (callCount === 1) return 'ses_empty|||Empty session|||1700000005000|||/code/project1\n'
+        return ''
+      }
+      return ''
+    })
+
+    const result = getOpenCodeSession('ses_empty', knownProjects)
+    expect(result).not.toBeNull()
+    expect(result?.messages).toEqual([])
   })
 })

--- a/backend/src/history/opencode.ts
+++ b/backend/src/history/opencode.ts
@@ -12,46 +12,60 @@ import { execSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
-import type { SessionProjectContext, SessionSummary } from '../agents/types.js'
+import type {
+  SessionDetails,
+  SessionMessage,
+  SessionProjectContext,
+  SessionSummary,
+} from '../agents/types.js'
 
 const OPENCODE_DB_PATH =
   process.env['OPENCODE_DB_PATH'] ?? join(homedir(), '.local', 'share', 'opencode', 'opencode.db')
 
 const OPENCODE_AGENT_ID = 'opencode'
 
+function isSqlite3Available(): boolean {
+  try {
+    execSync('sqlite3 -version', { stdio: 'ignore' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+function runQuery(query: string): string | null {
+  try {
+    return execSync(`sqlite3 -separator '|||' "${OPENCODE_DB_PATH}" "${query}"`, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+  } catch {
+    return null
+  }
+}
+
 export function readOpenCodeSessions(knownProjects: SessionProjectContext[]): SessionSummary[] {
   if (!existsSync(OPENCODE_DB_PATH)) {
     return []
   }
 
-  // Ensure sqlite3 is available in PATH
-  try {
-    execSync('sqlite3 -version', { stdio: 'ignore' })
-  } catch {
+  if (!isSqlite3Available()) {
     return []
   }
 
   // Query sessions joined with projects to get the worktree path
   const query = `
-    SELECT 
-      s.id, 
-      s.title, 
-      s.time_updated, 
-      p.worktree 
-    FROM session s 
+    SELECT
+      s.id,
+      s.title,
+      s.time_updated,
+      p.worktree
+    FROM session s
     JOIN project p ON s.project_id = p.id;
   `
 
-  let stdout: string
-  try {
-    // Execute query and output as tab-separated values (sqlite3 default for raw output is pipe-separated, we use -separator to be explicit)
-    stdout = execSync(`sqlite3 -separator '|||' "${OPENCODE_DB_PATH}" "${query}"`, {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    })
-  } catch {
-    return []
-  }
+  const stdout = runQuery(query)
+  if (stdout === null) return []
 
   const results: SessionSummary[] = []
   const lines = stdout.split('\n')
@@ -82,6 +96,86 @@ export function readOpenCodeSessions(knownProjects: SessionProjectContext[]): Se
   }
 
   return results
+}
+
+export function getOpenCodeSession(
+  sessionId: string,
+  knownProjects: SessionProjectContext[]
+): SessionDetails | null {
+  if (!existsSync(OPENCODE_DB_PATH)) {
+    return null
+  }
+
+  if (!isSqlite3Available()) {
+    return null
+  }
+
+  // Fetch session metadata (title, updatedAt, project path)
+  const safeId = sessionId.replace(/'/g, "''")
+  const metaQuery = `
+    SELECT s.id, s.title, s.time_updated, p.worktree
+    FROM session s
+    JOIN project p ON s.project_id = p.id
+    WHERE s.id = '${safeId}'
+    LIMIT 1;
+  `
+
+  const metaOut = runQuery(metaQuery)
+  if (!metaOut?.trim()) return null
+
+  const metaParts = metaOut.trim().split('|||')
+  if (metaParts.length < 4) return null
+
+  const [, title, timeUpdatedStr, worktree] = metaParts
+  const timeUpdated = parseInt(timeUpdatedStr ?? '0', 10)
+  if (isNaN(timeUpdated) || timeUpdated === 0) return null
+
+  const project = resolveProject(worktree ?? '', knownProjects)
+  if (!project) return null
+
+  // Fetch messages: join message with its text parts, ordered by creation time
+  const messagesQuery = `
+    SELECT m.id, json_extract(m.data, '$.role'), json_extract(p.data, '$.text')
+    FROM message m
+    JOIN part p ON p.message_id = m.id
+    WHERE m.session_id = '${safeId}'
+      AND json_extract(p.data, '$.type') = 'text'
+    ORDER BY m.time_created ASC, p.time_created ASC;
+  `
+
+  const msgOut = runQuery(messagesQuery)
+  const messages: SessionMessage[] = []
+
+  if (msgOut) {
+    let msgIndex = 0
+    for (const line of msgOut.split('\n')) {
+      if (!line.trim()) continue
+      const parts = line.split('|||')
+      if (parts.length < 3) continue
+
+      const [msgId, role, text] = parts
+      const content = text?.trim()
+      if (!content) continue
+      if (role !== 'user' && role !== 'assistant') continue
+
+      messages.push({
+        id: msgId ?? `msg-${msgIndex}`,
+        role: role as 'user' | 'assistant',
+        content,
+      })
+      msgIndex++
+    }
+  }
+
+  return {
+    id: sessionId,
+    title: title ?? 'OpenCode session',
+    updatedAt: new Date(timeUpdated).toISOString(),
+    agentId: OPENCODE_AGENT_ID,
+    project,
+    source: 'history',
+    messages,
+  }
 }
 
 function resolveProject(

--- a/frontend/src/hooks/useAgUiChat.ts
+++ b/frontend/src/hooks/useAgUiChat.ts
@@ -90,6 +90,11 @@ export function useAgUiChat({
   const activeSessionRef = useRef<string | null>(sessionId)
   const pendingRouteSessionRef = useRef<string | null>(null)
   const didBootstrapRef = useRef(false)
+  // Stable ref to the latest loadSession so the bootstrap effect doesn't need it
+  // in its dependency array (which would cause infinite re-bootstrap loops).
+  const loadSessionRef = useRef<
+    ((id: string, syncRoute?: boolean) => Promise<SessionDetails | null>) | null
+  >(null)
 
   useEffect(() => {
     if (agentId) {
@@ -213,6 +218,10 @@ export function useAgUiChat({
       sessionId,
     ]
   )
+
+  // Keep the ref in sync so the bootstrap effect can call the latest version
+  // without declaring loadSession as a dependency.
+  loadSessionRef.current = loadSession
 
   useEffect(() => {
     if (!sessionId) return
@@ -383,7 +392,7 @@ export function useAgUiChat({
         if (preferredSession) {
           activeSessionRef.current = preferredSession.id
           setCurrentSessionId(preferredSession.id)
-          await loadSession(preferredSession.id, false)
+          await loadSessionRef.current!(preferredSession.id, false)
           return
         }
 
@@ -423,7 +432,6 @@ export function useAgUiChat({
     currentAgentId,
     currentProjectId,
     fetchJson,
-    loadSession,
     onAgentSelected,
     onProjectSelected,
     onSessionSelected,
@@ -435,6 +443,7 @@ export function useAgUiChat({
     if (!currentSessionId) return
 
     activeSessionRef.current = currentSessionId
+    setErrorMessage(null)
     const sse = new EventSource(`/api/stream?sessionId=${encodeURIComponent(currentSessionId)}`)
 
     sse.addEventListener(EventType.RUN_STARTED, () => {


### PR DESCRIPTION
## Summary

- **Bug 1 (connecting chip stuck):** The bootstrap `useEffect` captured `loadSession` as a direct dependency. Because `loadSession` is a `useCallback` that depends on `onAgentSelected`, `onProjectSelected`, and `onSessionSelected` (which change identity each render), the bootstrap re-ran in a loop, resetting `didBootstrapRef` and keeping `currentSessionId` null — so `ready` stayed false and the chip never showed "Connected". Fix: `loadSession` is now accessed through a `loadSessionRef` ref, removing it from the bootstrap dependency array.
- **Bug 2 (history session 404):** `registry.getSession()` only checked live in-memory adapters. History sessions exist in `GET /api/sessions` but `GET /api/sessions/:id` always returned 404. Fix: added `getGeminiSession`, `getCopilotSession`, and `getOpenCodeSession` to the three history providers; `getHistorySession()` in `index.ts` tries them all and is wired into `registry.getSession()` as a fallback.
- **Bug 3 (stale SSE error):** When SSE disconnected it set `errorMessage`, which was never cleared when a new connection opened. Fix: `setErrorMessage(null)` at the top of the SSE `useEffect`.

## Tests

Added unit tests for all three new `getSession` functions (`gemini.test.ts`, expanded `copilot.test.ts` and `opencode.test.ts`). All 91 backend tests pass.

Closes #38